### PR TITLE
add ChiaConnection and helpers

### DIFF
--- a/chia_connection.js
+++ b/chia_connection.js
@@ -1,0 +1,62 @@
+const fs = require("fs");
+const os = require("os");
+
+/**
+ * Encapsulates the specific details needed to connect to a chia service.
+ */
+class ChiaConnection {
+  /**
+   *
+   * @param {string} service - The service name - see ServiceNames
+   * @param {string} host - The host (ip or hostname) of the chia service.
+   * @param {number} port - The port of the chia service.
+   * @param {string} key_path - The path to the key file for the service (can have ~).
+   * @param {string} cert_path - The path to the cert file for the service (can have ~).
+   * @param {number} timeout_seconds - The timeout in seconds for the connection.
+   */
+  constructor(service, host, port, key_path, cert_path, timeout_seconds) {
+    this.service = service;
+    this.host = host;
+    this.port = port;
+    this.key_path = key_path;
+    this.cert_path = cert_path;
+    this.timeout_seconds = timeout_seconds;
+  }
+
+  /**
+   * @returns {object} The options for the WebSocket
+   * or Https connection. This includes reading the
+   * cert and key files from disk
+   */
+  createClientOptions() {
+    return {
+      rejectUnauthorized: false,
+      keepAlive: true,
+      key: fs.readFileSync(untildify(this.key_path)),
+      cert: fs.readFileSync(untildify(this.cert_path)),
+    };
+  }
+
+  /** formatted address */
+  get serviceAddress() {
+    if (this.service === "daemon") {
+      return `wss://${this.host}:${this.port}`;
+    }
+    return `https://${this.host}:${this.port}`;
+  }
+}
+
+/**
+ * Resolves paths like ~/.chia/mainnet to their fully qualified equivalent in a platform safe manner.
+ * @param {string} pathWithTilde - A path that may or may not be rooted in the user's home folder.
+ * @returns Fully qualified path, i.e. /home/user/.chia instead of ~/.chia.
+ */
+function untildify(pathWithTilde) {
+  const homeDirectory = os.homedir();
+
+  return homeDirectory
+    ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
+    : pathWithTilde;
+}
+
+module.exports = ChiaConnection;

--- a/connection_factory.js
+++ b/connection_factory.js
@@ -1,0 +1,68 @@
+const { getChiaRoot } = require("./index");
+const ChiaConnection = require("./chia_connection");
+
+const ServiceNames = {
+  Daemon: "daemon",
+  FullNode: "full_node",
+  Wallet: "wallet",
+  Farmer: "farmer",
+  Harvester: "harvester",
+  Crawler: "crawler",
+  DataLayer: "data_layer",
+};
+
+/**
+ * The default ports for the services. (https://docs.chia.net/rpc)
+ */
+const DefaultServicePorts = {
+  daemon: 55400,
+  full_node: 8555,
+  wallet: 9256,
+  farmer: 8559,
+  harvester: 8560,
+  crawler: 8561,
+  data_layer: 8562,
+};
+
+/**
+ * Creates a connection to a service.
+ * @param {string} serviceName - The service for the command. One of the ServiceNames constants.
+ * @param {string} host - The host (ip or hostname) of the chia service.
+ * @param {string} root - The path to the chia root directory. (can also be a path to the ssl directory)
+ * @param {int} timeoutSeconds - The timeout in seconds for the connection.
+ * @param {object} portMap - The port map for the services. Defaults to DefaultServicePorts.
+ * @returns {ChiaConnection} The connection object
+ */
+function createConnection(
+  serviceName,
+  host,
+  root,
+  timeoutSeconds = 30,
+  portMap = DefaultServicePorts
+) {
+  // if the user didn't specify a root, try to find it
+  if (root === undefined) {
+    root = getChiaRoot();
+  }
+
+  // if the root isn't an ssl path, assume it's the
+  // chia root and append the ssl path
+  if (!root.endsWith("/config/ssl")) {
+    root = `${root}/config/ssl`;
+  }
+
+  return new ChiaConnection(
+    serviceName,
+    host,
+    portMap[serviceName],
+    `${root}/${serviceName}/private_${serviceName}.key`,
+    `${root}/${serviceName}/private_${serviceName}.crt`,
+    timeoutSeconds
+  );
+}
+
+module.exports = {
+  ServiceNames,
+  DefaultServicePorts,
+  createConnection,
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
-const os = require('os');
-const path = require('path');
+const os = require("os");
+const path = require("path");
+const ChiaConnection = require("./chia_connection");
+const {
+  ServiceNames,
+  DefaultServicePorts,
+  createConnection,
+} = require("./connection_factory");
 
 let chiaRoot = null;
 
@@ -16,8 +22,12 @@ const getChiaRoot = () => {
   }
 
   return chiaRoot;
-}
+};
 
 module.exports = {
   getChiaRoot,
-}
+  ChiaConnection,
+  ServiceNames,
+  DefaultServicePorts,
+  createConnection,
+};


### PR DESCRIPTION
Added two things:

1) A class to encapsulate the things needed to connection to a chia service (wss or https)
2) some helpers in the `connection_factory.js` with defaults and a helper method that reflects chia conventions.

The ultimate goal for stuff I do is decouple the connection details from the environment config and decouple both of those from the rpc detail. 